### PR TITLE
Add front matter to all markdown files in subdirectories

### DIFF
--- a/api-reference/authentication.md
+++ b/api-reference/authentication.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # API Authentication
 
 All requests to the Ona Intelligence Layer API must be authenticated. This guide explains how to authenticate your requests.

--- a/api-reference/data-ingestion/overview.md
+++ b/api-reference/data-ingestion/overview.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Data Ingestion API Overview
 
 The Data Ingestion API provides endpoints for uploading historical and real-time solar production data to the platform. These endpoints trigger automated data processing pipelines that standardize, enrich, and prepare your data for forecasting and analysis.

--- a/api-reference/data-ingestion/upload-nowcast.md
+++ b/api-reference/data-ingestion/upload-nowcast.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Data Ingestion API: Upload Nowcast Data
 
 Upload real-time solar production data for forecasting and monitoring. This endpoint accepts CSV files and triggers real-time processing pipelines.

--- a/api-reference/data-ingestion/upload-train.md
+++ b/api-reference/data-ingestion/upload-train.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Data Ingestion API: Upload Training Data
 
 Upload historical solar production data for model training. This endpoint accepts CSV files and triggers the automated training pipeline.

--- a/api-reference/forecasting/forecast.md
+++ b/api-reference/forecasting/forecast.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Forecasting API: Generate Forecast
 
 Generate an energy production forecast for a customer and site. This endpoint uses trained ML models to predict future energy production based on historical patterns and weather forecasts.

--- a/api-reference/forecasting/freemium-forecast.md
+++ b/api-reference/forecasting/freemium-forecast.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # API Reference: Freemium Forecasting API
 
 This document provides a detailed reference for the Freemium Forecasting API, which allows you to generate a 24-hour forecast from a CSV file of historical data. This is a simplified endpoint designed for quick testing and evaluation.

--- a/api-reference/forecasting/overview.md
+++ b/api-reference/forecasting/overview.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Forecasting API Overview
 
 This section provides complete documentation for all forecasting-related API endpoints. Our forecasting APIs enable you to generate accurate energy forecasts for renewable energy assets, supporting use cases from energy trading to maintenance planning.

--- a/api-reference/overview.md
+++ b/api-reference/overview.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # API Reference Overview
 
 This section provides a detailed, parameter-level reference for all public APIs of the Ona Intelligence Layer. It is designed for **Developers** who are building applications on top of our platform.

--- a/api-reference/terminal/assets.md
+++ b/api-reference/terminal/assets.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API: Asset Management
 
 Manage your solar asset inventory through the Terminal API. Add assets, list all assets, or retrieve specific asset details.

--- a/api-reference/terminal/bom.md
+++ b/api-reference/terminal/bom.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API: Bill of Materials
 
 Generate bills of materials (BOM) for maintenance work. This endpoint helps prepare maintenance activities by identifying required parts and components.

--- a/api-reference/terminal/detect.md
+++ b/api-reference/terminal/detect.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API: Fault Detection
 
 Run fault detection on your assets to identify anomalies and potential issues. This endpoint triggers the Observe stage of the OODA loop.

--- a/api-reference/terminal/diagnose.md
+++ b/api-reference/terminal/diagnose.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API: AI Diagnostics
 
 Execute AI diagnostics on detected faults to identify root causes and recommended actions. This endpoint triggers the Orient stage of the OODA loop.

--- a/api-reference/terminal/forecast.md
+++ b/api-reference/terminal/forecast.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API: Forecast Results
 
 Retrieve stored ML forecast results for your sites. This endpoint provides access to previously generated forecasts with detailed metrics and confidence intervals.

--- a/api-reference/terminal/interpolation.md
+++ b/api-reference/terminal/interpolation.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API: Interpolation Results
 
 Retrieve stored interpolation (gap-filling) results for your sites. This endpoint provides access to ML-powered data interpolation that fills missing data gaps in your time series.

--- a/api-reference/terminal/ml-models.md
+++ b/api-reference/terminal/ml-models.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API: ML Model Registry
 
 Retrieve the shared catalog of all available ML models. This endpoint provides metadata about trained models including performance metrics, training parameters, and artifact locations.

--- a/api-reference/terminal/ooda.md
+++ b/api-reference/terminal/ooda.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API: OODA Summaries
 
 Retrieve ML-enhanced OODA (Observe-Orient-Decide-Act) summaries for your assets. These summaries include fault detection results, AI diagnostics, severity assessments, energy-at-risk calculations, and recommended actions.

--- a/api-reference/terminal/order.md
+++ b/api-reference/terminal/order.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API: Work Orders
 
 Create and manage work orders for maintenance activities. This endpoint supports the Act stage of the OODA loop by enabling work order creation and tracking.

--- a/api-reference/terminal/overview.md
+++ b/api-reference/terminal/overview.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API Overview
 
 The Terminal API is the central API handler for the entire Operations & Maintenance (O&M) OODA workflow. It provides endpoints for asset management, fault detection, diagnostics, maintenance scheduling, and accessing ML model results.

--- a/api-reference/terminal/schedule.md
+++ b/api-reference/terminal/schedule.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API: Maintenance Scheduling
 
 Create and manage maintenance schedules for your assets. This endpoint supports the Decide stage of the OODA loop by enabling proactive maintenance planning.

--- a/api-reference/terminal/track.md
+++ b/api-reference/terminal/track.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Terminal API: Job Tracking
 
 Subscribe to and manage job tracking subscriptions. This endpoint enables real-time monitoring of work order status and completion.

--- a/guides/data-management/data-quality.md
+++ b/guides/data-management/data-quality.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Data Quality and Standardization
 
 When you upload a CSV file, our platform automatically performs a series of data standardization steps. This process is designed to handle the wide variety of data formats used in the industry.

--- a/guides/data-management/overview.md
+++ b/guides/data-management/overview.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Data Management Overview
 
 The quality of your input data is the single most important factor in generating accurate forecasts. This guide outlines the best practices for preparing and uploading your data to the Ona Intelligence Layer, ensuring optimal forecast accuracy and reliable results.

--- a/guides/data-management/preparing-data.md
+++ b/guides/data-management/preparing-data.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Preparing Your Data
 
 The quality of your input data is the single most important factor in generating accurate forecasts. This guide outlines the best practices for preparing your data for the Ona Intelligence Layer.

--- a/guides/data-management/uploading-data.md
+++ b/guides/data-management/uploading-data.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Uploading Your Data
 
 You can upload your data via the API as shown in the [Get Started](../../get-started.md) guide. This guide provides detailed instructions for uploading both training data (for model training) and nowcast data (for real-time forecasting).

--- a/guides/developer-guide.md
+++ b/guides/developer-guide.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Guide: Developer Guide
 
 This guide provides the core principles and processes for developers contributing to the Ona Intelligence Layer platform. Adherence to these guidelines is mandatory to ensure code quality, continuity, and accountability.

--- a/guides/forecasting/generating-forecasts.md
+++ b/guides/forecasting/generating-forecasts.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Generating Forecasts
 
 As shown in the [Get Started](../../get-started.md) guide, generating a forecast is as simple as making a `POST` request to the `/api/v1/freemium-forecast` endpoint with your historical data. This guide provides detailed instructions for both the freemium API (for quick testing) and the full forecasting API (for production use).

--- a/guides/forecasting/improving-accuracy.md
+++ b/guides/forecasting/improving-accuracy.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Improving Forecast Accuracy
 
 Forecast accuracy is influenced by several factors, and understanding these factors helps you optimize your forecasts for production use. This guide covers the key elements that impact accuracy and provides actionable tips for achieving better results.

--- a/guides/forecasting/interpreting-results.md
+++ b/guides/forecasting/interpreting-results.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Interpreting Forecast Results
 
 The API returns a rich JSON object with your forecast. Let's break down the key components:

--- a/guides/forecasting/overview.md
+++ b/guides/forecasting/overview.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Forecasting Overview
 
 This guide covers the essentials of generating and interpreting forecasts with the Ona Intelligence Layer. Whether you're generating your first forecast or optimizing accuracy for production use, this guide provides the knowledge and best practices you need to succeed.

--- a/guides/overview.md
+++ b/guides/overview.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Overview of Guides
 
 This section provides practical, task-oriented guides to help you solve specific problems and achieve your business goals using the Ona Intelligence Layer. These guides are designed for both **Beginners** and **Developers**, offering step-by-step instructions, code examples, and best practices for common tasks.

--- a/guides/portfolio-management/overview.md
+++ b/guides/portfolio-management/overview.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Guide: Portfolio Management
 
 The Ona Intelligence Layer provides powerful tools for managing and analyzing a portfolio of renewable energy assets. This guide introduces the key concepts of portfolio management on our platform.

--- a/products/analyst.md
+++ b/products/analyst.md
@@ -1,4 +1,7 @@
 ---
+layout: default
+---
+---
 title: "EnergyAnalyst"
 layout: default
 nav_order: 3

--- a/products/distributed-compute.md
+++ b/products/distributed-compute.md
@@ -1,4 +1,7 @@
 ---
+layout: default
+---
+---
 title: "Ona Edge"
 layout: default
 nav_order: 4

--- a/products/index.md
+++ b/products/index.md
@@ -1,4 +1,7 @@
 ---
+layout: default
+---
+---
 title: "Products & Services"
 layout: default
 nav_order: 4

--- a/products/terminal.md
+++ b/products/terminal.md
@@ -1,4 +1,7 @@
 ---
+layout: default
+---
+---
 title: "Ona Terminal"
 layout: default
 nav_order: 1

--- a/technical-concepts/data-standardization.md
+++ b/technical-concepts/data-standardization.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Technical Concepts: Data Standardization
 
 A major challenge in the energy industry is the lack of data standardization. Different equipment manufacturers, monitoring platforms, and logging systems all produce data in slightly different formats. The Ona Intelligence Layer is designed to handle this complexity through a robust, automated data standardization pipeline.

--- a/technical-concepts/machine-learning/forecasting-models.md
+++ b/technical-concepts/machine-learning/forecasting-models.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Technical Concepts: Machine Learning Models
 
 The Ona Intelligence Layer uses a sophisticated ensemble of machine learning models to provide highly accurate forecasts and detect anomalies in your energy assets. This document provides a high-level overview of the key models we use.

--- a/technical-concepts/machine-learning/overview.md
+++ b/technical-concepts/machine-learning/overview.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Machine Learning Overview
 
 This section provides technical details about the machine learning models and algorithms used in the Ona Intelligence Layer. Understanding these concepts helps you make informed decisions about model selection, data preparation, and forecast optimization.

--- a/technical-concepts/overview.md
+++ b/technical-concepts/overview.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Technical Concepts Overview
 
 This section provides a deeper look into the core technologies and methodologies that power the Ona Intelligence Layer. It is designed for **Developers** and other technical users who want to understand *how* our platform works under the hood, including our machine learning models, data processing pipelines, and architectural decisions.

--- a/use-cases/avaron-infrastructure.md
+++ b/use-cases/avaron-infrastructure.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Use Case: Avaron Infrastructure
 
 **Unified Intelligence for Multi-Stakeholder Coordination**

--- a/use-cases/cummins-portfolio.md
+++ b/use-cases/cummins-portfolio.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Use Case: Cummins Portfolio
 
 **Maintaining Operations Through Severe Data Loss**

--- a/use-cases/oam.md
+++ b/use-cases/oam.md
@@ -1,4 +1,7 @@
 ---
+layout: default
+---
+---
 title: "O&M Optimization"
 layout: default
 nav_order: 1

--- a/use-cases/overview.md
+++ b/use-cases/overview.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Use Cases Overview
 
 This section showcases real-world use cases and case studies demonstrating how the Ona Intelligence Layer is used to solve complex problems and deliver measurable business value. These stories are designed for **Decision Makers** and **Beginners** who want to understand the practical applications of our technology and see concrete examples of ROI and operational improvements.

--- a/use-cases/sibaya-casino.md
+++ b/use-cases/sibaya-casino.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 # Use Case: Sibaya Casino
 
 **Achieving Forecasting Accuracy with Limited Historical Data**


### PR DESCRIPTION
Jekyll requires YAML front matter to process markdown files and convert them to HTML. Files without front matter are served as static files, causing raw markdown to display in the browser.

Added 'layout: default' front matter to all .md files in:
- guides/
- api-reference/
- technical-concepts/
- use-cases/
- products/

This ensures all markdown files are properly converted to HTML by Jekyll.