### PR TITLE
Remove .md extensions from HTML links in overview pages

### DIFF
--- a/api-reference/data-ingestion/overview.md
+++ b/api-reference/data-ingestion/overview.md
@@ -7,8 +7,8 @@ The Data Ingestion API provides endpoints for uploading historical and real-time
 
 ## Endpoints
 
-*   **[Upload Training Data](./upload-train.md)**: Upload historical data for model training
-*   **[Upload Nowcast Data](./upload-nowcast.md)**: Upload real-time data for forecasting
+*   **[Upload Training Data](./upload-train)**: Upload historical data for model training
+*   **[Upload Nowcast Data](./upload-nowcast)**: Upload real-time data for forecasting
 
 ## API Design Principles
 
@@ -40,12 +40,12 @@ When you upload data:
 
 To upload your first dataset:
 
-1. [Prepare your data](../../guides/data-management/preparing-data.md) in the correct format
-2. [Upload training data](./upload-train.md) for historical datasets
-3. [Upload nowcast data](./upload-nowcast.md) for real-time updates
+1. [Prepare your data](../../guides/data-management/preparing-data) in the correct format
+2. [Upload training data](./upload-train) for historical datasets
+3. [Upload nowcast data](./upload-nowcast) for real-time updates
 
 ## See Also
 
-- [Get Started](../../get-started.md) - Quick start tutorial
-- [Data Management Guides](../../guides/data-management/overview.md) - How-to guides for data preparation
-- [Technical Concepts](../../technical-concepts/data-standardization.md) - Data standardization details
+- [Get Started](../../get-started) - Quick start tutorial
+- [Data Management Guides](../../guides/data-management/overview) - How-to guides for data preparation
+- [Technical Concepts](../../technical-concepts/data-standardization) - Data standardization details

--- a/api-reference/data-ingestion/upload-nowcast.md
+++ b/api-reference/data-ingestion/upload-nowcast.md
@@ -78,7 +78,7 @@ Your CSV file must include:
 - **Power/Energy column**: Current kWh, kW, or power values
 - **Optional columns**: kVArh, kVA, PF, temperature, irradiance, etc.
 
-See [Preparing Data](../../guides/data-management/preparing-data.md) for detailed format requirements.
+See [Preparing Data](../../guides/data-management/preparing-data) for detailed format requirements.
 
 ## Response Format
 
@@ -122,7 +122,7 @@ After upload, your data goes through:
 
 ## See Also
 
-- [Data Ingestion API Overview](./overview.md) - Complete API reference
-- [Upload Training Data](./upload-train.md) - Upload historical data
-- [Preparing Data](../../guides/data-management/preparing-data.md) - Data format guide
-- [Forecasting API](../forecasting/overview.md) - Generate forecasts
+- [Data Ingestion API Overview](./overview) - Complete API reference
+- [Upload Training Data](./upload-train) - Upload historical data
+- [Preparing Data](../../guides/data-management/preparing-data) - Data format guide
+- [Forecasting API](../forecasting/overview) - Generate forecasts

--- a/api-reference/data-ingestion/upload-train.md
+++ b/api-reference/data-ingestion/upload-train.md
@@ -78,7 +78,7 @@ Your CSV file must include:
 - **Power/Energy column**: kWh, kW, or power values
 - **Optional columns**: kVArh, kVA, PF, temperature, irradiance, etc.
 
-See [Preparing Data](../../guides/data-management/preparing-data.md) for detailed format requirements.
+See [Preparing Data](../../guides/data-management/preparing-data) for detailed format requirements.
 
 ## Response Format
 
@@ -122,7 +122,7 @@ After upload, your data goes through:
 
 ## See Also
 
-- [Data Ingestion API Overview](./overview.md) - Complete API reference
-- [Upload Nowcast Data](./upload-nowcast.md) - Upload real-time data
-- [Preparing Data](../../guides/data-management/preparing-data.md) - Data format guide
-- [Data Quality](../../guides/data-management/data-quality.md) - Data quality requirements
+- [Data Ingestion API Overview](./overview) - Complete API reference
+- [Upload Nowcast Data](./upload-nowcast) - Upload real-time data
+- [Preparing Data](../../guides/data-management/preparing-data) - Data format guide
+- [Data Quality](../../guides/data-management/data-quality) - Data quality requirements

--- a/api-reference/forecasting/forecast.md
+++ b/api-reference/forecasting/forecast.md
@@ -128,8 +128,8 @@ Before generating forecasts, ensure:
 
 ## See Also
 
-- [Forecasting API Overview](./overview.md) - Complete API reference
-- [Freemium Forecast](./freemium-forecast.md) - Free tier CSV-based forecast
-- [Terminal API: Forecast Results](../terminal/forecast.md) - Retrieve stored forecast results
-- [Forecasting Guides](../../guides/forecasting/overview.md) - How-to guides
-- [Technical Concepts](../../technical-concepts/machine-learning/forecasting-models.md) - ML model details
+- [Forecasting API Overview](./overview) - Complete API reference
+- [Freemium Forecast](./freemium-forecast) - Free tier CSV-based forecast
+- [Terminal API: Forecast Results](../terminal/forecast) - Retrieve stored forecast results
+- [Forecasting Guides](../../guides/forecasting/overview) - How-to guides
+- [Technical Concepts](../../technical-concepts/machine-learning/forecasting-models) - ML model details

--- a/api-reference/forecasting/freemium-forecast.md
+++ b/api-reference/forecasting/freemium-forecast.md
@@ -5,7 +5,7 @@ layout: default
 
 This document provides a detailed reference for the Freemium Forecasting API, which allows you to generate a 24-hour forecast from a CSV file of historical data. This is a simplified endpoint designed for quick testing and evaluation.
 
-**Note**: For production use with trained models, see the [Generate Forecast](./forecast.md) endpoint which uses the `ForecastResponse.json` schema.
+**Note**: For production use with trained models, see the [Generate Forecast](./forecast) endpoint which uses the `ForecastResponse.json` schema.
 
 This API is designed for **Developers**.
 

--- a/api-reference/forecasting/overview.md
+++ b/api-reference/forecasting/overview.md
@@ -9,7 +9,7 @@ Our APIs follow RESTful conventions and return JSON responses. All endpoints req
 
 ## Quick Start
 
-To generate your first forecast, see the [Get Started](../../get-started.md) guide. This tutorial walks you through making your first API call using our freemium endpoint.
+To generate your first forecast, see the [Get Started](../../get-started) guide. This tutorial walks you through making your first API call using our freemium endpoint.
 
 ```bash
 curl -X POST \
@@ -26,19 +26,19 @@ curl -X POST \
   <div class="overview-card">
     <h3>Generate Forecast</h3>
     <p>Generate forecasts using trained ML models with the full forecasting API. This endpoint supports customer-specific models, custom forecast horizons, and advanced parameters. Uses the `ForecastResponse.json` schema for structured responses.</p>
-    <a href="./forecast.md" class="card-link">View Endpoint →</a>
+    <a href="./forecast" class="card-link">View Endpoint →</a>
   </div>
   
   <div class="overview-card">
     <h3>Freemium Forecast</h3>
     <p>Generate a 24-hour forecast from a CSV file using our free tier API. Perfect for testing and evaluation, this endpoint requires no authentication and provides immediate results. Ideal for quick prototyping and initial assessments.</p>
-    <a href="./freemium-forecast.md" class="card-link">View Endpoint →</a>
+    <a href="./freemium-forecast" class="card-link">View Endpoint →</a>
   </div>
   
   <div class="overview-card">
     <h3>Authentication</h3>
     <p>Learn how to authenticate API requests using API keys and tokens. This guide covers key management, request signing, and security best practices. Required for all production endpoints.</p>
-    <a href="../authentication.md" class="card-link">View Guide →</a>
+    <a href="../authentication" class="card-link">View Guide →</a>
   </div>
 </div>
 
@@ -74,23 +74,23 @@ Forecast responses include:
 
 These endpoints are most frequently used:
 
-- **[Freemium Forecast](./freemium-forecast.md)**: Quick testing and evaluation
-- **[Generate Forecast](./forecast.md)**: Production forecasting with custom models
-- **[Authentication](../authentication.md)**: API key management
+- **[Freemium Forecast](./freemium-forecast)**: Quick testing and evaluation
+- **[Generate Forecast](./forecast)**: Production forecasting with custom models
+- **[Authentication](../authentication)**: API key management
 
 ## Next Steps
 
 Now that you understand the forecasting APIs:
 
-1. **Try Freemium API**: Start with [Freemium Forecast](./freemium-forecast.md) for quick testing
-2. **Set Up Authentication**: Review [Authentication](../authentication.md) for API keys
-3. **Generate Forecasts**: Use [Generate Forecast](./forecast.md) for production use
-4. **Explore Guides**: Check [Forecasting Guides](../../guides/forecasting/overview.md) for best practices
-5. **Review Technical Details**: Learn about [ML Models](../../technical-concepts/machine-learning/forecasting-models.md)
+1. **Try Freemium API**: Start with [Freemium Forecast](./freemium-forecast) for quick testing
+2. **Set Up Authentication**: Review [Authentication](../authentication) for API keys
+3. **Generate Forecasts**: Use [Generate Forecast](./forecast) for production use
+4. **Explore Guides**: Check [Forecasting Guides](../../guides/forecasting/overview) for best practices
+5. **Review Technical Details**: Learn about [ML Models](../../technical-concepts/machine-learning/forecasting-models)
 
 ## See Also
 
-- [Get Started](../../get-started.md) - Quick start tutorial
-- [Forecasting Guides](../../guides/forecasting/overview.md) - How-to guides for forecasting
-- [Technical Concepts](../../technical-concepts/machine-learning/forecasting-models.md) - ML model details
-- [API Reference Overview](../overview.md) - Complete API documentation index
+- [Get Started](../../get-started) - Quick start tutorial
+- [Forecasting Guides](../../guides/forecasting/overview) - How-to guides for forecasting
+- [Technical Concepts](../../technical-concepts/machine-learning/forecasting-models) - ML model details
+- [API Reference Overview](../overview) - Complete API documentation index

--- a/api-reference/overview.md
+++ b/api-reference/overview.md
@@ -9,38 +9,38 @@ This section provides a detailed, parameter-level reference for all public APIs 
 
 ### Authentication & Setup
 
-*   **[Authentication](./authentication.md)**: Learn how to authenticate your requests to the API.
+*   **[Authentication](./authentication)**: Learn how to authenticate your requests to the API.
 
 ### Forecasting APIs
 
-*   **[Forecasting API](./forecasting/overview.md)**: Generate energy production forecasts
-  *   [Freemium Forecast](./forecasting/freemium-forecast.md): Generate a 24-hour forecast from a CSV file (free tier)
+*   **[Forecasting API](./forecasting/overview)**: Generate energy production forecasts
+  *   [Freemium Forecast](./forecasting/freemium-forecast): Generate a 24-hour forecast from a CSV file (free tier)
 
 ### Terminal API (OODA Workflow)
 
 The Terminal API provides endpoints for the complete OODA (Observe-Orient-Decide-Act) workflow:
 
-*   **[Terminal API Overview](./terminal/overview.md)**: Complete reference for OODA workflow APIs
-  *   **[Asset Management](./terminal/assets.md)**: Create, list, and retrieve solar assets
-  *   **[Fault Detection](./terminal/detect.md)**: Run fault detection on assets (Observe)
-  *   **[AI Diagnostics](./terminal/diagnose.md)**: Execute AI diagnostics on faults (Orient)
-  *   **[Maintenance Scheduling](./terminal/schedule.md)**: Create maintenance schedules (Decide)
-  *   **[Bill of Materials](./terminal/bom.md)**: Generate BOMs for maintenance
-  *   **[Work Orders](./terminal/order.md)**: Create and manage work orders (Act)
-  *   **[Job Tracking](./terminal/track.md)**: Subscribe to job status updates
+*   **[Terminal API Overview](./terminal/overview)**: Complete reference for OODA workflow APIs
+  *   **[Asset Management](./terminal/assets)**: Create, list, and retrieve solar assets
+  *   **[Fault Detection](./terminal/detect)**: Run fault detection on assets (Observe)
+  *   **[AI Diagnostics](./terminal/diagnose)**: Execute AI diagnostics on faults (Orient)
+  *   **[Maintenance Scheduling](./terminal/schedule)**: Create maintenance schedules (Decide)
+  *   **[Bill of Materials](./terminal/bom)**: Generate BOMs for maintenance
+  *   **[Work Orders](./terminal/order)**: Create and manage work orders (Act)
+  *   **[Job Tracking](./terminal/track)**: Subscribe to job status updates
 
 ### ML Integration APIs
 
-*   **[Forecast Results](./terminal/forecast.md)**: Retrieve stored ML forecast results
-*   **[Interpolation Results](./terminal/interpolation.md)**: Retrieve gap-filling interpolation results
-*   **[ML Model Registry](./terminal/ml-models.md)**: Access catalog of available ML models
-*   **[OODA Summaries](./terminal/ooda.md)**: Retrieve ML-enhanced OODA summaries with severity and energy-at-risk
+*   **[Forecast Results](./terminal/forecast)**: Retrieve stored ML forecast results
+*   **[Interpolation Results](./terminal/interpolation)**: Retrieve gap-filling interpolation results
+*   **[ML Model Registry](./terminal/ml-models)**: Access catalog of available ML models
+*   **[OODA Summaries](./terminal/ooda)**: Retrieve ML-enhanced OODA summaries with severity and energy-at-risk
 
 ### Data Ingestion APIs
 
-*   **[Data Ingestion API Overview](./data-ingestion/overview.md)**: Upload historical and real-time data
-  *   **[Upload Training Data](./data-ingestion/upload-train.md)**: Upload historical data for model training
-  *   **[Upload Nowcast Data](./data-ingestion/upload-nowcast.md)**: Upload real-time data for forecasting
+*   **[Data Ingestion API Overview](./data-ingestion/overview)**: Upload historical and real-time data
+  *   **[Upload Training Data](./data-ingestion/upload-train)**: Upload historical data for model training
+  *   **[Upload Nowcast Data](./data-ingestion/upload-nowcast)**: Upload real-time data for forecasting
 
 ## API Design Principles
 

--- a/api-reference/terminal/assets.md
+++ b/api-reference/terminal/assets.md
@@ -167,6 +167,6 @@ curl -X POST https://api.asoba.co/terminal/assets \
 
 ## See Also
 
-- [Terminal API Overview](./overview.md) - Complete API reference
-- [Fault Detection](./detect.md) - Run detection on assets
-- [Authentication](../authentication.md) - API authentication guide
+- [Terminal API Overview](./overview) - Complete API reference
+- [Fault Detection](./detect) - Run detection on assets
+- [Authentication](../authentication) - API authentication guide

--- a/api-reference/terminal/bom.md
+++ b/api-reference/terminal/bom.md
@@ -113,6 +113,6 @@ curl -X POST https://api.asoba.co/terminal/bom \
 
 ## See Also
 
-- [Terminal API Overview](./overview.md) - Complete API reference
-- [Maintenance Scheduling](./schedule.md) - Create maintenance schedules
-- [Work Orders](./order.md) - Create work orders
+- [Terminal API Overview](./overview) - Complete API reference
+- [Maintenance Scheduling](./schedule) - Create maintenance schedules
+- [Work Orders](./order) - Create work orders

--- a/api-reference/terminal/detect.md
+++ b/api-reference/terminal/detect.md
@@ -91,6 +91,6 @@ curl -X POST https://api.asoba.co/terminal/detect \
 
 ## See Also
 
-- [Terminal API Overview](./overview.md) - Complete API reference
-- [AI Diagnostics](./diagnose.md) - Run diagnostics on detected faults
-- [OODA Summaries](./ooda.md) - Get ML-enhanced summaries
+- [Terminal API Overview](./overview) - Complete API reference
+- [AI Diagnostics](./diagnose) - Run diagnostics on detected faults
+- [OODA Summaries](./ooda) - Get ML-enhanced summaries

--- a/api-reference/terminal/diagnose.md
+++ b/api-reference/terminal/diagnose.md
@@ -93,6 +93,6 @@ curl -X POST https://api.asoba.co/terminal/diagnose \
 
 ## See Also
 
-- [Terminal API Overview](./overview.md) - Complete API reference
-- [Fault Detection](./detect.md) - Run detection first
-- [OODA Summaries](./ooda.md) - Get ML-enhanced summaries
+- [Terminal API Overview](./overview) - Complete API reference
+- [Fault Detection](./detect) - Run detection first
+- [OODA Summaries](./ooda) - Get ML-enhanced summaries

--- a/api-reference/terminal/forecast.md
+++ b/api-reference/terminal/forecast.md
@@ -136,7 +136,7 @@ curl -X POST https://api.asoba.co/terminal/forecast \
 
 ## See Also
 
-- [Terminal API Overview](./overview.md) - Complete API reference
-- [Forecasting API](../forecasting/overview.md) - Generate new forecasts
-- [ML Model Registry](./ml-models.md) - View available models
-- [Forecasting Guides](../../guides/forecasting/overview.md) - How-to guides
+- [Terminal API Overview](./overview) - Complete API reference
+- [Forecasting API](../forecasting/overview) - Generate new forecasts
+- [ML Model Registry](./ml-models) - View available models
+- [Forecasting Guides](../../guides/forecasting/overview) - How-to guides

--- a/api-reference/terminal/interpolation.md
+++ b/api-reference/terminal/interpolation.md
@@ -137,6 +137,6 @@ The service uses ML-powered interpolation methods that adapt to your data patter
 
 ## See Also
 
-- [Terminal API Overview](./overview.md) - Complete API reference
-- [Data Management Guides](../../guides/data-management/overview.md) - How-to guides for data preparation
-- [Technical Concepts](../../technical-concepts/data-standardization.md) - Data standardization details
+- [Terminal API Overview](./overview) - Complete API reference
+- [Data Management Guides](../../guides/data-management/overview) - How-to guides for data preparation
+- [Technical Concepts](../../technical-concepts/data-standardization) - Data standardization details

--- a/api-reference/terminal/ml-models.md
+++ b/api-reference/terminal/ml-models.md
@@ -143,6 +143,6 @@ curl -X POST https://api.asoba.co/terminal/ml-models \
 
 ## See Also
 
-- [Terminal API Overview](./overview.md) - Complete API reference
-- [Forecast Results](./forecast.md) - Retrieve forecast predictions
-- [Technical Concepts](../../technical-concepts/machine-learning/overview.md) - ML model details
+- [Terminal API Overview](./overview) - Complete API reference
+- [Forecast Results](./forecast) - Retrieve forecast predictions
+- [Technical Concepts](../../technical-concepts/machine-learning/overview) - ML model details

--- a/api-reference/terminal/ooda.md
+++ b/api-reference/terminal/ooda.md
@@ -144,8 +144,8 @@ The `energy_at_risk_kw` field estimates the potential energy production loss if 
 
 ## See Also
 
-- [Terminal API Overview](./overview.md) - Complete API reference
-- [Fault Detection](./detect.md) - Run detection on assets
-- [AI Diagnostics](./diagnose.md) - Execute diagnostics
-- [Maintenance Scheduling](./schedule.md) - Create maintenance schedules
-- [OODA Workflow Guides](../../guides/portfolio-management/overview.md) - How-to guides
+- [Terminal API Overview](./overview) - Complete API reference
+- [Fault Detection](./detect) - Run detection on assets
+- [AI Diagnostics](./diagnose) - Execute diagnostics
+- [Maintenance Scheduling](./schedule) - Create maintenance schedules
+- [OODA Workflow Guides](../../guides/portfolio-management/overview) - How-to guides

--- a/api-reference/terminal/order.md
+++ b/api-reference/terminal/order.md
@@ -109,7 +109,7 @@ curl -X POST https://api.asoba.co/terminal/order \
 
 ## See Also
 
-- [Terminal API Overview](./overview.md) - Complete API reference
-- [Maintenance Scheduling](./schedule.md) - Create schedules
-- [Bill of Materials](./bom.md) - Generate BOMs
-- [Job Tracking](./track.md) - Track order status
+- [Terminal API Overview](./overview) - Complete API reference
+- [Maintenance Scheduling](./schedule) - Create schedules
+- [Bill of Materials](./bom) - Generate BOMs
+- [Job Tracking](./track) - Track order status

--- a/api-reference/terminal/overview.md
+++ b/api-reference/terminal/overview.md
@@ -18,20 +18,20 @@ The OODA (Observe-Orient-Decide-Act) loop is a decision-making framework that en
 
 ### OODA Workflow Endpoints
 
-*   **[Asset Management](./assets.md)**: Create, list, and retrieve solar asset details
-*   **[Fault Detection](./detect.md)**: Run fault detection on assets
-*   **[AI Diagnostics](./diagnose.md)**: Execute AI diagnostics on detected faults
-*   **[Maintenance Scheduling](./schedule.md)**: Create and manage maintenance schedules
-*   **[Bill of Materials](./bom.md)**: Generate bills of materials for maintenance
-*   **[Work Orders](./order.md)**: Create and manage work orders
-*   **[Job Tracking](./track.md)**: Subscribe to and manage job tracking
+*   **[Asset Management](./assets)**: Create, list, and retrieve solar asset details
+*   **[Fault Detection](./detect)**: Run fault detection on assets
+*   **[AI Diagnostics](./diagnose)**: Execute AI diagnostics on detected faults
+*   **[Maintenance Scheduling](./schedule)**: Create and manage maintenance schedules
+*   **[Bill of Materials](./bom)**: Generate bills of materials for maintenance
+*   **[Work Orders](./order)**: Create and manage work orders
+*   **[Job Tracking](./track)**: Subscribe to and manage job tracking
 
 ### ML Integration Endpoints
 
-*   **[Forecast Results](./forecast.md)**: Retrieve stored ML forecast results
-*   **[Interpolation Results](./interpolation.md)**: Retrieve gap-filling interpolation results
-*   **[ML Model Registry](./ml-models.md)**: Access the catalog of available ML models
-*   **[OODA Summaries](./ooda.md)**: Retrieve ML-enhanced OODA summaries with severity and energy-at-risk
+*   **[Forecast Results](./forecast)**: Retrieve stored ML forecast results
+*   **[Interpolation Results](./interpolation)**: Retrieve gap-filling interpolation results
+*   **[ML Model Registry](./ml-models)**: Access the catalog of available ML models
+*   **[OODA Summaries](./ooda)**: Retrieve ML-enhanced OODA summaries with severity and energy-at-risk
 
 ## API Design Principles
 
@@ -44,7 +44,7 @@ The Terminal API follows standard RESTful conventions:
 
 ## Authentication
 
-All Terminal API endpoints require authentication. See [Authentication](../authentication.md) for details.
+All Terminal API endpoints require authentication. See [Authentication](../authentication) for details.
 
 ## Base URL
 
@@ -56,13 +56,13 @@ https://api.asoba.co
 
 To get started with the Terminal API:
 
-1. [Authenticate your requests](../authentication.md)
-2. [Add an asset](./assets.md) to your inventory
-3. [Run fault detection](./detect.md) on your assets
-4. [Retrieve forecast results](./forecast.md) for your sites
+1. [Authenticate your requests](../authentication)
+2. [Add an asset](./assets) to your inventory
+3. [Run fault detection](./detect) on your assets
+4. [Retrieve forecast results](./forecast) for your sites
 
 ## See Also
 
-- [Get Started](../../get-started.md) - Quick start tutorial
-- [OODA Workflow Guides](../../guides/portfolio-management/overview.md) - How-to guides for O&M workflows
-- [Technical Concepts](../../technical-concepts/machine-learning/overview.md) - ML model details
+- [Get Started](../../get-started) - Quick start tutorial
+- [OODA Workflow Guides](../../guides/portfolio-management/overview) - How-to guides for O&M workflows
+- [Technical Concepts](../../technical-concepts/machine-learning/overview) - ML model details

--- a/api-reference/terminal/schedule.md
+++ b/api-reference/terminal/schedule.md
@@ -106,6 +106,6 @@ curl -X POST https://api.asoba.co/terminal/schedule \
 
 ## See Also
 
-- [Terminal API Overview](./overview.md) - Complete API reference
-- [Bill of Materials](./bom.md) - Generate BOM for maintenance
-- [Work Orders](./order.md) - Create work orders
+- [Terminal API Overview](./overview) - Complete API reference
+- [Bill of Materials](./bom) - Generate BOM for maintenance
+- [Work Orders](./order) - Create work orders

--- a/api-reference/terminal/track.md
+++ b/api-reference/terminal/track.md
@@ -109,6 +109,6 @@ curl -X POST https://api.asoba.co/terminal/track \
 
 ## See Also
 
-- [Terminal API Overview](./overview.md) - Complete API reference
-- [Work Orders](./order.md) - Create work orders
-- [Maintenance Scheduling](./schedule.md) - Create schedules
+- [Terminal API Overview](./overview) - Complete API reference
+- [Work Orders](./order) - Create work orders
+- [Maintenance Scheduling](./schedule) - Create schedules

--- a/guides/data-management/data-quality.md
+++ b/guides/data-management/data-quality.md
@@ -10,10 +10,10 @@ When you upload a CSV file, our platform automatically performs a series of data
 3.  **Timezone Normalization**: All timestamps are converted to UTC to ensure consistency.
 4.  **Data Cleaning**: The platform handles missing values and outliers in your data to improve model stability.
 
-For a more detailed explanation of this process, please see the [Data Standardization](../../technical-concepts/data-standardization.md) page in our Technical Concepts section.
+For a more detailed explanation of this process, please see the [Data Standardization](../../technical-concepts/data-standardization) page in our Technical Concepts section.
 
 ## See Also
 
-- [Preparing Data](./preparing-data.md) - Data format requirements
-- [Uploading Data](./uploading-data.md) - How to upload data
-- [Data Standardization](../../technical-concepts/data-standardization.md) - Technical details on standardization process
+- [Preparing Data](./preparing-data) - Data format requirements
+- [Uploading Data](./uploading-data) - How to upload data
+- [Data Standardization](../../technical-concepts/data-standardization) - Technical details on standardization process

--- a/guides/data-management/overview.md
+++ b/guides/data-management/overview.md
@@ -9,7 +9,7 @@ Proper data management involves understanding format requirements, ensuring data
 
 ## Quick Start
 
-For a quick tutorial on uploading data, see the [Get Started](../../get-started.md) guide. This walkthrough demonstrates uploading a CSV file and generating your first forecast.
+For a quick tutorial on uploading data, see the [Get Started](../../get-started) guide. This walkthrough demonstrates uploading a CSV file and generating your first forecast.
 
 ```bash
 curl -X POST \
@@ -26,19 +26,19 @@ curl -X POST \
   <div class="overview-card">
     <h3>Preparing Data</h3>
     <p>Learn about data format requirements, column naming conventions, timestamp formats, and unit specifications. This guide covers everything you need to know to format your data correctly before upload, ensuring smooth processing and accurate forecasts.</p>
-    <a href="./preparing-data.md" class="card-link">Learn More →</a>
+    <a href="./preparing-data" class="card-link">Learn More →</a>
   </div>
   
   <div class="overview-card">
     <h3>Uploading Data</h3>
     <p>Step-by-step guide to uploading your data via the API, including authentication, request formatting, and handling responses. Learn about both training data uploads (for model training) and nowcast data uploads (for real-time forecasting).</p>
-    <a href="./uploading-data.md" class="card-link">Learn More →</a>
+    <a href="./uploading-data" class="card-link">Learn More →</a>
   </div>
   
   <div class="overview-card">
     <h3>Data Quality</h3>
     <p>Understand how our platform standardizes and processes your data, including automatic detection and correction of common issues. Learn about data validation, error handling, and how to ensure your data meets quality requirements for optimal forecast accuracy.</p>
-    <a href="./data-quality.md" class="card-link">Learn More →</a>
+    <a href="./data-quality" class="card-link">Learn More →</a>
   </div>
 </div>
 
@@ -46,10 +46,10 @@ curl -X POST \
 
 These data management guides are most frequently accessed:
 
-- **[Preparing Data](./preparing-data.md)**: Data format requirements and best practices
-- **[Uploading Data](./uploading-data.md)**: Step-by-step upload instructions
-- **[Data Quality](./data-quality.md)**: Understanding data standardization
-- **[Get Started](../../get-started.md)**: Quick start tutorial
+- **[Preparing Data](./preparing-data)**: Data format requirements and best practices
+- **[Uploading Data](./uploading-data)**: Step-by-step upload instructions
+- **[Data Quality](./data-quality)**: Understanding data standardization
+- **[Get Started](../../get-started)**: Quick start tutorial
 
 ## Core Concepts
 
@@ -75,15 +75,15 @@ Training data is used to train customer-specific models, while nowcast data is u
 
 Now that you understand data management:
 
-1. **Prepare Your Data**: Review [Preparing Data](./preparing-data.md) for format requirements
-2. **Upload Your Data**: Follow [Uploading Data](./uploading-data.md) for step-by-step instructions
-3. **Understand Processing**: Read [Data Quality](./data-quality.md) to learn about standardization
-4. **Generate Forecasts**: Use the [Forecasting Guide](../forecasting/overview.md) to create forecasts
-5. **Review Technical Details**: Explore [Data Standardization](../../technical-concepts/data-standardization.md) for technical information
+1. **Prepare Your Data**: Review [Preparing Data](./preparing-data) for format requirements
+2. **Upload Your Data**: Follow [Uploading Data](./uploading-data) for step-by-step instructions
+3. **Understand Processing**: Read [Data Quality](./data-quality) to learn about standardization
+4. **Generate Forecasts**: Use the [Forecasting Guide](../forecasting/overview) to create forecasts
+5. **Review Technical Details**: Explore [Data Standardization](../../technical-concepts/data-standardization) for technical information
 
 ## See Also
 
-- [Get Started](../../get-started.md) - Quick start tutorial
-- [Forecasting](../forecasting/overview.md) - Generating forecasts guide
-- [Data Standardization](../../technical-concepts/data-standardization.md) - Technical details on standardization process
-- [API Reference](../../api-reference/data-ingestion/overview.md) - Data ingestion API documentation
+- [Get Started](../../get-started) - Quick start tutorial
+- [Forecasting](../forecasting/overview) - Generating forecasts guide
+- [Data Standardization](../../technical-concepts/data-standardization) - Technical details on standardization process
+- [API Reference](../../api-reference/data-ingestion/overview) - Data ingestion API documentation

--- a/guides/data-management/preparing-data.md
+++ b/guides/data-management/preparing-data.md
@@ -34,6 +34,6 @@ For best results, we recommend providing data with at least an hourly granularit
 
 ## See Also
 
-- [Uploading Data](./uploading-data.md) - How to upload your prepared data
-- [Data Quality](./data-quality.md) - Understanding data standardization
-- [Get Started](../../get-started.md) - Quick start tutorial
+- [Uploading Data](./uploading-data) - How to upload your prepared data
+- [Data Quality](./data-quality) - Understanding data standardization
+- [Get Started](../../get-started) - Quick start tutorial

--- a/guides/data-management/uploading-data.md
+++ b/guides/data-management/uploading-data.md
@@ -3,7 +3,7 @@ layout: default
 ---
 # Uploading Your Data
 
-You can upload your data via the API as shown in the [Get Started](../../get-started.md) guide. This guide provides detailed instructions for uploading both training data (for model training) and nowcast data (for real-time forecasting).
+You can upload your data via the API as shown in the [Get Started](../../get-started) guide. This guide provides detailed instructions for uploading both training data (for model training) and nowcast data (for real-time forecasting).
 
 ## Upload Methods
 
@@ -53,7 +53,7 @@ The API expects files as part of a `multipart/form-data` request. Your CSV file 
 - **Power/Energy Column**: Numeric values (kW or kWh)
 - **Optional Metadata**: Site name, location, etc.
 
-See [Preparing Data](./preparing-data.md) for detailed format requirements.
+See [Preparing Data](./preparing-data) for detailed format requirements.
 
 ## Authentication
 
@@ -63,7 +63,7 @@ All data upload endpoints require authentication via API keys. Include your API 
 Authorization: Bearer YOUR_API_KEY
 ```
 
-See [Authentication](../../api-reference/authentication.md) for API key management.
+See [Authentication](../../api-reference/authentication) for API key management.
 
 ## Response Handling
 
@@ -76,26 +76,26 @@ Successful uploads return a JSON response with:
 
 ## Common Issues
 
-**File Format**: Ensure CSV file matches required format (see [Preparing Data](./preparing-data.md))
+**File Format**: Ensure CSV file matches required format (see [Preparing Data](./preparing-data))
 
 **Authentication**: Verify API key is correctly included in headers
 
 **File Size**: Keep files under 10MB for optimal performance
 
-**Data Quality**: Check [Data Quality](./data-quality.md) guide for validation requirements
+**Data Quality**: Check [Data Quality](./data-quality) guide for validation requirements
 
 ## Next Steps
 
 After uploading your data:
 
-1. **Prepare Data**: Review [Preparing Data](./preparing-data.md) for format requirements
-2. **Check Quality**: Understand [Data Quality](./data-quality.md) validation
-3. **Generate Forecasts**: Use [Forecasting Guide](../forecasting/overview.md) to create forecasts
-4. **Review API**: Check [Data Ingestion API](../../api-reference/data-ingestion/overview.md) documentation
+1. **Prepare Data**: Review [Preparing Data](./preparing-data) for format requirements
+2. **Check Quality**: Understand [Data Quality](./data-quality) validation
+3. **Generate Forecasts**: Use [Forecasting Guide](../forecasting/overview) to create forecasts
+4. **Review API**: Check [Data Ingestion API](../../api-reference/data-ingestion/overview) documentation
 
 ## See Also
 
-- [Preparing Data](./preparing-data.md) - Data format requirements
-- [Data Quality](./data-quality.md) - Understanding data standardization
-- [API Reference](../../api-reference/forecasting/freemium-forecast.md) - Complete API documentation
-- [Authentication](../../api-reference/authentication.md) - API key management
+- [Preparing Data](./preparing-data) - Data format requirements
+- [Data Quality](./data-quality) - Understanding data standardization
+- [API Reference](../../api-reference/forecasting/freemium-forecast) - Complete API documentation
+- [Authentication](../../api-reference/authentication) - API key management

--- a/guides/forecasting/generating-forecasts.md
+++ b/guides/forecasting/generating-forecasts.md
@@ -3,7 +3,7 @@ layout: default
 ---
 # Generating Forecasts
 
-As shown in the [Get Started](../../get-started.md) guide, generating a forecast is as simple as making a `POST` request to the `/api/v1/freemium-forecast` endpoint with your historical data. This guide provides detailed instructions for both the freemium API (for quick testing) and the full forecasting API (for production use).
+As shown in the [Get Started](../../get-started) guide, generating a forecast is as simple as making a `POST` request to the `/api/v1/freemium-forecast` endpoint with your historical data. This guide provides detailed instructions for both the freemium API (for quick testing) and the full forecasting API (for production use).
 
 ## Using the Freemium API
 
@@ -54,7 +54,7 @@ The quality of your forecast depends heavily on the quality of the data you prov
 - **Coverage**: Complete data with minimal gaps
 - **History**: At least 30 days of historical data for best results
 
-See the [Data Management](../data-management/overview.md) guide for detailed data preparation instructions.
+See the [Data Management](../data-management/overview) guide for detailed data preparation instructions.
 
 ## Response Handling
 
@@ -79,14 +79,14 @@ Successful requests return a JSON response with forecast data:
 
 After generating your first forecast:
 
-1. **Interpret Results**: Learn how to read forecast output in [Interpreting Results](./interpreting-results.md)
-2. **Improve Accuracy**: Follow tips in [Improving Accuracy](./improving-accuracy.md)
-3. **Prepare Data**: Review [Data Management](../data-management/overview.md) for best practices
-4. **Explore API**: Check [API Reference](../../api-reference/forecasting/overview.md) for complete documentation
+1. **Interpret Results**: Learn how to read forecast output in [Interpreting Results](./interpreting-results)
+2. **Improve Accuracy**: Follow tips in [Improving Accuracy](./improving-accuracy)
+3. **Prepare Data**: Review [Data Management](../data-management/overview) for best practices
+4. **Explore API**: Check [API Reference](../../api-reference/forecasting/overview) for complete documentation
 
 ## See Also
 
-- [Get Started](../../get-started.md) - Quick start tutorial
-- [Data Management](../data-management/overview.md) - Data preparation guide
-- [API Reference](../../api-reference/forecasting/freemium-forecast.md) - Complete API documentation
-- [Interpreting Results](./interpreting-results.md) - Understanding forecast output
+- [Get Started](../../get-started) - Quick start tutorial
+- [Data Management](../data-management/overview) - Data preparation guide
+- [API Reference](../../api-reference/forecasting/freemium-forecast) - Complete API documentation
+- [Interpreting Results](./interpreting-results) - Understanding forecast output

--- a/guides/forecasting/improving-accuracy.md
+++ b/guides/forecasting/improving-accuracy.md
@@ -16,7 +16,7 @@ The more clean, high-resolution historical data you provide, the better the fore
 - **Accurate Timestamps**: Properly formatted ISO 8601 timestamps
 - **Consistent Units**: Standardized power/energy units throughout
 
-Poor data quality is the most common cause of low forecast accuracy. See our [Data Management](../data-management/overview.md) guide for data preparation best practices.
+Poor data quality is the most common cause of low forecast accuracy. See our [Data Management](../data-management/overview) guide for data preparation best practices.
 
 ### Weather Data
 
@@ -36,7 +36,7 @@ Customer-specific models will always outperform generic models after sufficient 
 - **Training Data**: At least 6 months of historical data recommended
 - **Model Selection**: Choose based on your accuracy requirements
 
-For a deeper dive into the machine learning models we use, see the [Machine Learning Models](../../technical-concepts/machine-learning/forecasting-models.md) page in our Technical Concepts section.
+For a deeper dive into the machine learning models we use, see the [Machine Learning Models](../../technical-concepts/machine-learning/forecasting-models) page in our Technical Concepts section.
 
 ## Best Practices
 
@@ -75,15 +75,15 @@ If you're experiencing low forecast accuracy:
 
 Now that you understand how to improve accuracy:
 
-1. **Prepare Data**: Review [Data Management](../data-management/overview.md) for best practices
-2. **Train Models**: Use [Data Ingestion API](../../api-reference/data-ingestion/upload-train.md) for custom models
-3. **Generate Forecasts**: Follow [Generating Forecasts](./generating-forecasts.md) guide
+1. **Prepare Data**: Review [Data Management](../data-management/overview) for best practices
+2. **Train Models**: Use [Data Ingestion API](../../api-reference/data-ingestion/upload-train) for custom models
+3. **Generate Forecasts**: Follow [Generating Forecasts](./generating-forecasts) guide
 4. **Monitor Performance**: Track accuracy metrics over time
 5. **Optimize Continuously**: Iterate on data quality and model selection
 
 ## See Also
 
-- [Generating Forecasts](./generating-forecasts.md) - How to generate forecasts
-- [Interpreting Results](./interpreting-results.md) - Understanding forecast output
-- [Data Management](../data-management/overview.md) - Data quality best practices
-- [Machine Learning Models](../../technical-concepts/machine-learning/forecasting-models.md) - Technical details on models
+- [Generating Forecasts](./generating-forecasts) - How to generate forecasts
+- [Interpreting Results](./interpreting-results) - Understanding forecast output
+- [Data Management](../data-management/overview) - Data quality best practices
+- [Machine Learning Models](../../technical-concepts/machine-learning/forecasting-models) - Technical details on models

--- a/guides/forecasting/interpreting-results.md
+++ b/guides/forecasting/interpreting-results.md
@@ -36,6 +36,6 @@ The API returns a rich JSON object with your forecast. Let's break down the key 
 
 ## See Also
 
-- [Generating Forecasts](./generating-forecasts.md) - How to generate forecasts
-- [Improving Accuracy](./improving-accuracy.md) - Tips for better forecast accuracy
-- [API Reference](../../api-reference/forecasting/freemium-forecast.md) - Complete response schema
+- [Generating Forecasts](./generating-forecasts) - How to generate forecasts
+- [Improving Accuracy](./improving-accuracy) - Tips for better forecast accuracy
+- [API Reference](../../api-reference/forecasting/freemium-forecast) - Complete response schema

--- a/guides/forecasting/overview.md
+++ b/guides/forecasting/overview.md
@@ -9,7 +9,7 @@ Forecasting is at the core of our platform, enabling you to predict energy produ
 
 ## Quick Start
 
-To generate your first forecast, see the [Get Started](../../get-started.md) guide. This 5-minute tutorial walks you through uploading historical data and receiving a 24-hour forecast using our freemium API.
+To generate your first forecast, see the [Get Started](../../get-started) guide. This 5-minute tutorial walks you through uploading historical data and receiving a 24-hour forecast using our freemium API.
 
 ```bash
 curl -X POST \
@@ -20,7 +20,7 @@ curl -X POST \
   https://api.asoba.co/v1/freemium-forecast
 ```
 
-For complete API documentation, see the [Forecasting API Reference](../../api-reference/forecasting/freemium-forecast.md).
+For complete API documentation, see the [Forecasting API Reference](../../api-reference/forecasting/freemium-forecast).
 
 ## What You Can Find Here
 
@@ -28,19 +28,19 @@ For complete API documentation, see the [Forecasting API Reference](../../api-re
   <div class="overview-card">
     <h3>Generating Forecasts</h3>
     <p>Learn how to generate forecasts using our API, including request formatting, parameter selection, and response handling. This guide covers both the freemium API for quick testing and the full forecasting API for production use.</p>
-    <a href="./generating-forecasts.md" class="card-link">Learn More →</a>
+    <a href="./generating-forecasts" class="card-link">Learn More →</a>
   </div>
   
   <div class="overview-card">
     <h3>Interpreting Results</h3>
     <p>Understand forecast response structure and key fields, including timestamp formats, confidence intervals, and summary statistics. Learn how to extract actionable insights from forecast data for your specific use case.</p>
-    <a href="./interpreting-results.md" class="card-link">Learn More →</a>
+    <a href="./interpreting-results" class="card-link">Learn More →</a>
   </div>
   
   <div class="overview-card">
     <h3>Improving Accuracy</h3>
     <p>Discover tips and best practices for achieving better forecast accuracy, including data quality requirements, model selection strategies, and common pitfalls to avoid. Learn how to optimize your forecasts for production use.</p>
-    <a href="./improving-accuracy.md" class="card-link">Learn More →</a>
+    <a href="./improving-accuracy" class="card-link">Learn More →</a>
   </div>
 </div>
 
@@ -48,10 +48,10 @@ For complete API documentation, see the [Forecasting API Reference](../../api-re
 
 These forecasting guides are most frequently accessed:
 
-- **[Generating Forecasts](./generating-forecasts.md)**: Step-by-step guide to creating forecasts
-- **[Interpreting Results](./interpreting-results.md)**: Understanding forecast output
-- **[Improving Accuracy](./improving-accuracy.md)**: Tips for better performance
-- **[Get Started](../../get-started.md)**: Quick start tutorial
+- **[Generating Forecasts](./generating-forecasts)**: Step-by-step guide to creating forecasts
+- **[Interpreting Results](./interpreting-results)**: Understanding forecast output
+- **[Improving Accuracy](./improving-accuracy)**: Tips for better performance
+- **[Get Started](../../get-started)**: Quick start tutorial
 
 ## Core Concepts
 
@@ -67,7 +67,7 @@ Choose between generic models (available immediately) and customer-specific mode
 
 ### Data Requirements
 
-Forecast accuracy depends heavily on data quality. High-resolution historical data (hourly or better), complete coverage, and minimal gaps lead to the best results. See our [Data Management](../data-management/overview.md) guide for details.
+Forecast accuracy depends heavily on data quality. High-resolution historical data (hourly or better), complete coverage, and minimal gaps lead to the best results. See our [Data Management](../data-management/overview) guide for details.
 
 ### Accuracy Metrics
 
@@ -77,15 +77,15 @@ We provide multiple accuracy metrics including MAPE (Mean Absolute Percentage Er
 
 Now that you understand forecasting:
 
-1. **Generate Your First Forecast**: Follow the [Get Started](../../get-started.md) guide
-2. **Learn About Data**: Review [Data Management](../data-management/overview.md) for data preparation
-3. **Explore API Options**: Check the [Forecasting API Reference](../../api-reference/forecasting/overview.md)
-4. **Optimize Accuracy**: Read [Improving Accuracy](./improving-accuracy.md) for best practices
-5. **Understand Models**: Learn about [Machine Learning Models](../../technical-concepts/machine-learning/forecasting-models.md)
+1. **Generate Your First Forecast**: Follow the [Get Started](../../get-started) guide
+2. **Learn About Data**: Review [Data Management](../data-management/overview) for data preparation
+3. **Explore API Options**: Check the [Forecasting API Reference](../../api-reference/forecasting/overview)
+4. **Optimize Accuracy**: Read [Improving Accuracy](./improving-accuracy) for best practices
+5. **Understand Models**: Learn about [Machine Learning Models](../../technical-concepts/machine-learning/forecasting-models)
 
 ## See Also
 
-- [Get Started](../../get-started.md) - Quick start tutorial
-- [Data Management](../data-management/overview.md) - Data preparation guide
-- [API Reference](../../api-reference/forecasting/freemium-forecast.md) - Complete API documentation
-- [Machine Learning Models](../../technical-concepts/machine-learning/forecasting-models.md) - Technical details on models
+- [Get Started](../../get-started) - Quick start tutorial
+- [Data Management](../data-management/overview) - Data preparation guide
+- [API Reference](../../api-reference/forecasting/freemium-forecast) - Complete API documentation
+- [Machine Learning Models](../../technical-concepts/machine-learning/forecasting-models) - Technical details on models

--- a/guides/overview.md
+++ b/guides/overview.md
@@ -9,7 +9,7 @@ Whether you're generating your first forecast, preparing data for upload, or man
 
 ## Quick Start
 
-The fastest way to get started is our [Get Started](../get-started.md) guide, which walks you through making your first API call in just 5 minutes. You'll learn how to upload historical data and generate a 24-hour forecast using our freemium API.
+The fastest way to get started is our [Get Started](../get-started) guide, which walks you through making your first API call in just 5 minutes. You'll learn how to upload historical data and generate a 24-hour forecast using our freemium API.
 
 ```bash
 curl -X POST \
@@ -26,25 +26,25 @@ curl -X POST \
   <div class="overview-card">
     <h3>Forecasting</h3>
     <p>Learn how to generate and interpret forecasts, understand accuracy metrics, and improve the performance of your predictions. This comprehensive guide covers everything from basic forecast generation to advanced accuracy optimization techniques.</p>
-    <a href="./forecasting/overview.md" class="card-link">Learn More →</a>
+    <a href="./forecasting/overview" class="card-link">Learn More →</a>
   </div>
   
   <div class="overview-card">
     <h3>Data Management</h3>
     <p>A complete guide to preparing your data for our platform, including required formats, standardization, and best practices for uploading. Learn how to ensure your data quality meets our requirements for optimal forecast accuracy.</p>
-    <a href="./data-management/overview.md" class="card-link">Learn More →</a>
+    <a href="./data-management/overview" class="card-link">Learn More →</a>
   </div>
   
   <div class="overview-card">
     <h3>Portfolio Management</h3>
     <p>For users managing multiple assets, this guide covers how to analyze portfolio-wide performance, identify outliers, and streamline reporting. Discover techniques for scaling your operations across hundreds of sites.</p>
-    <a href="./portfolio-management/overview.md" class="card-link">Learn More →</a>
+    <a href="./portfolio-management/overview" class="card-link">Learn More →</a>
   </div>
   
   <div class="overview-card">
     <h3>Developer Guide</h3>
     <p>Information for developers contributing to or building on top of the platform, including coding guidelines, development processes, and integration patterns. Learn how to extend the platform's capabilities.</p>
-    <a href="./developer-guide.md" class="card-link">Learn More →</a>
+    <a href="./developer-guide" class="card-link">Learn More →</a>
   </div>
 </div>
 
@@ -52,10 +52,10 @@ curl -X POST \
 
 These guides are the most frequently accessed and provide essential knowledge for getting started:
 
-- **[Get Started](../get-started.md)**: Make your first API call in 5 minutes
-- **[Generating Forecasts](./forecasting/generating-forecasts.md)**: Step-by-step guide to creating forecasts
-- **[Preparing Data](./data-management/preparing-data.md)**: Data format requirements and best practices
-- **[Improving Accuracy](./forecasting/improving-accuracy.md)**: Tips for achieving better forecast performance
+- **[Get Started](../get-started)**: Make your first API call in 5 minutes
+- **[Generating Forecasts](./forecasting/generating-forecasts)**: Step-by-step guide to creating forecasts
+- **[Preparing Data](./data-management/preparing-data)**: Data format requirements and best practices
+- **[Improving Accuracy](./forecasting/improving-accuracy)**: Tips for achieving better forecast performance
 
 ## Core Concepts
 
@@ -70,14 +70,14 @@ Understanding these core concepts will help you get the most out of our guides:
 
 Now that you understand what's available in our guides section:
 
-1. **New Users**: Start with the [Get Started](../get-started.md) guide to make your first API call
-2. **Forecasting**: Explore the [Forecasting Guide](./forecasting/overview.md) to learn about generating and interpreting forecasts
-3. **Data Preparation**: Review the [Data Management Guide](./data-management/overview.md) to ensure your data meets our requirements
-4. **API Reference**: Dive into the [API Reference](../api-reference/overview.md) for complete endpoint documentation
-5. **Use Cases**: Check out [Real-World Examples](../use-cases/overview.md) to see how others are using the platform
+1. **New Users**: Start with the [Get Started](../get-started) guide to make your first API call
+2. **Forecasting**: Explore the [Forecasting Guide](./forecasting/overview) to learn about generating and interpreting forecasts
+3. **Data Preparation**: Review the [Data Management Guide](./data-management/overview) to ensure your data meets our requirements
+4. **API Reference**: Dive into the [API Reference](../api-reference/overview) for complete endpoint documentation
+5. **Use Cases**: Check out [Real-World Examples](../use-cases/overview) to see how others are using the platform
 
 ## See Also
 
-- [API Reference](../api-reference/overview.md) - Complete API documentation
-- [Technical Concepts](../technical-concepts/overview.md) - Deep dives into platform architecture
-- [Use Cases](../use-cases/overview.md) - Real-world examples and case studies
+- [API Reference](../api-reference/overview) - Complete API documentation
+- [Technical Concepts](../technical-concepts/overview) - Deep dives into platform architecture
+- [Use Cases](../use-cases/overview) - Real-world examples and case studies

--- a/technical-concepts/data-standardization.md
+++ b/technical-concepts/data-standardization.md
@@ -9,7 +9,7 @@ This content is designed for **Developers** and technical users.
 
 ## The Standardization Pipeline
 
-When you upload a CSV file to our platform (for example, via the [Freemium Forecasting API](./../api-reference/forecasting/freemium-forecast.md)), it passes through the following standardization steps:
+When you upload a CSV file to our platform (for example, via the [Freemium Forecasting API](./../api-reference/forecasting/freemium-forecast)), it passes through the following standardization steps:
 
 ### 1. CSV Parsing and Manufacturer Detection
 
@@ -32,7 +32,7 @@ Our standard schema includes fields like:
 
 Real-world data is often messy. Our pipeline includes several data cleaning steps:
 *   **Timestamp Normalization**: All timestamps are converted to UTC to prevent any ambiguity related to timezones.
-*   **Handling of Missing Values**: The platform can intelligently fill in missing data points using statistical methods like ARIMA, as described in the [Cummins Portfolio use case](./../use-cases/cummins-portfolio.md).
+*   **Handling of Missing Values**: The platform can intelligently fill in missing data points using statistical methods like ARIMA, as described in the [Cummins Portfolio use case](./../use-cases/cummins-portfolio).
 *   **Outlier Detection**: The platform identifies and flags anomalous readings that may be the result of sensor error.
 
 ## The Benefit: A Unified View

--- a/technical-concepts/machine-learning/forecasting-models.md
+++ b/technical-concepts/machine-learning/forecasting-models.md
@@ -25,12 +25,12 @@ To address this challenge, we use an ensemble of different models, each with its
 ### 1. Long Short-Term Memory (LSTM) Networks
 
 *   **What they are**: LSTMs are a type of recurrent neural network (RNN) that is particularly well-suited for time-series forecasting. They can learn long-term dependencies in the data, making them effective at capturing seasonal patterns.
-*   **How we use them**: LSTMs form the core of our forecasting engine. We use them to model the complex, non-linear relationships between weather, time of day, and energy production. We also use them for our "cross-portfolio transfer learning," as described in the [Sibaya Casino use case](./../use-cases/sibaya-casino.md).
+*   **How we use them**: LSTMs form the core of our forecasting engine. We use them to model the complex, non-linear relationships between weather, time of day, and energy production. We also use them for our "cross-portfolio transfer learning," as described in the [Sibaya Casino use case](./../use-cases/sibaya-casino).
 
 ### 2. Autoregressive Integrated Moving Average (ARIMA)
 
 *   **What it is**: ARIMA is a classical statistical model for time-series forecasting. It is particularly effective at modeling trends and seasonality in the data.
-*   **How we use it**: We use ARIMA for data reconstruction and interpolation, as demonstrated in the [Cummins Portfolio use case](./../use-cases/cummins-portfolio.md). It allows us to intelligently fill in missing data points with a high degree of accuracy.
+*   **How we use it**: We use ARIMA for data reconstruction and interpolation, as demonstrated in the [Cummins Portfolio use case](./../use-cases/cummins-portfolio). It allows us to intelligently fill in missing data points with a high degree of accuracy.
 
 ### 3. Anomaly Detection Models
 

--- a/technical-concepts/machine-learning/overview.md
+++ b/technical-concepts/machine-learning/overview.md
@@ -9,7 +9,7 @@ Our platform employs advanced machine learning techniques to deliver accurate en
 
 ## Quick Start
 
-To understand our machine learning approach, start by learning about [Forecasting Models](./forecasting-models.md), which explains the different model types and their characteristics. Then explore how models are trained using the [Data Ingestion API](../../api-reference/data-ingestion/upload-train.md).
+To understand our machine learning approach, start by learning about [Forecasting Models](./forecasting-models), which explains the different model types and their characteristics. Then explore how models are trained using the [Data Ingestion API](../../api-reference/data-ingestion/upload-train).
 
 ## What You Can Find Here
 
@@ -17,7 +17,7 @@ To understand our machine learning approach, start by learning about [Forecastin
   <div class="overview-card">
     <h3>Forecasting Models</h3>
     <p>Detailed explanation of the ML models used for energy forecasting, including architecture, training processes, and performance characteristics. Learn about generic models, customer-specific models, and how model selection impacts forecast accuracy.</p>
-    <a href="./forecasting-models.md" class="card-link">Learn More →</a>
+    <a href="./forecasting-models" class="card-link">Learn More →</a>
   </div>
 </div>
 
@@ -67,24 +67,24 @@ Model performance is measured using multiple metrics:
 
 These machine learning topics are frequently referenced:
 
-- **[Forecasting Models](./forecasting-models.md)**: Detailed model architecture and training
-- **[Model Training](../../api-reference/data-ingestion/upload-train.md)**: Upload training data for custom models
-- **[Forecast Accuracy](../../guides/forecasting/improving-accuracy.md)**: Factors affecting performance
-- **[Data Requirements](../../guides/data-management/overview.md)**: Data needed for model training
+- **[Forecasting Models](./forecasting-models)**: Detailed model architecture and training
+- **[Model Training](../../api-reference/data-ingestion/upload-train)**: Upload training data for custom models
+- **[Forecast Accuracy](../../guides/forecasting/improving-accuracy)**: Factors affecting performance
+- **[Data Requirements](../../guides/data-management/overview)**: Data needed for model training
 
 ## Next Steps
 
 Now that you understand our machine learning approach:
 
-1. **Learn About Models**: Explore [Forecasting Models](./forecasting-models.md) for detailed information
-2. **Train Custom Models**: Use [Data Ingestion API](../../api-reference/data-ingestion/upload-train.md) to upload training data
-3. **Optimize Accuracy**: Review [Forecast Accuracy Guide](../../guides/forecasting/improving-accuracy.md) for best practices
-4. **Prepare Data**: Check [Data Management Guide](../../guides/data-management/overview.md) for data requirements
-5. **Generate Forecasts**: Use [Forecasting Guides](../../guides/forecasting/overview.md) to create forecasts
+1. **Learn About Models**: Explore [Forecasting Models](./forecasting-models) for detailed information
+2. **Train Custom Models**: Use [Data Ingestion API](../../api-reference/data-ingestion/upload-train) to upload training data
+3. **Optimize Accuracy**: Review [Forecast Accuracy Guide](../../guides/forecasting/improving-accuracy) for best practices
+4. **Prepare Data**: Check [Data Management Guide](../../guides/data-management/overview) for data requirements
+5. **Generate Forecasts**: Use [Forecasting Guides](../../guides/forecasting/overview) to create forecasts
 
 ## See Also
 
-- [Forecasting Guides](../../guides/forecasting/overview.md) - How to use forecasting features
-- [API Reference](../../api-reference/forecasting/overview.md) - API documentation
-- [Data Standardization](../../technical-concepts/data-standardization.md) - Data processing details
-- [Data Management](../../guides/data-management/overview.md) - Data preparation guide
+- [Forecasting Guides](../../guides/forecasting/overview) - How to use forecasting features
+- [API Reference](../../api-reference/forecasting/overview) - API documentation
+- [Data Standardization](../../technical-concepts/data-standardization) - Data processing details
+- [Data Management](../../guides/data-management/overview) - Data preparation guide

--- a/technical-concepts/overview.md
+++ b/technical-concepts/overview.md
@@ -9,7 +9,7 @@ Understanding these technical concepts will help you make better decisions about
 
 ## Quick Start
 
-To get started with our technical concepts, we recommend beginning with [Data Standardization](./data-standardization.md) to understand how we process your data, then exploring [Machine Learning Models](./machine-learning/forecasting-models.md) to learn about our forecasting algorithms.
+To get started with our technical concepts, we recommend beginning with [Data Standardization](./data-standardization) to understand how we process your data, then exploring [Machine Learning Models](./machine-learning/forecasting-models) to learn about our forecasting algorithms.
 
 ## What You Can Find Here
 
@@ -17,13 +17,13 @@ To get started with our technical concepts, we recommend beginning with [Data St
   <div class="overview-card">
     <h3>Machine Learning Models</h3>
     <p>An overview of the different machine learning models we use for forecasting and anomaly detection. Learn about generic models, customer-specific models, and how model selection impacts forecast accuracy. Understand the algorithms, training processes, and performance characteristics of each model type.</p>
-    <a href="./machine-learning/forecasting-models.md" class="card-link">Learn More →</a>
+    <a href="./machine-learning/forecasting-models" class="card-link">Learn More →</a>
   </div>
   
   <div class="overview-card">
     <h3>Data Standardization</h3>
     <p>A comprehensive look at our automated process for ingesting, cleaning, and standardizing data from a wide variety of sources. Understand how we handle different data formats, time zones, units, and quality issues to ensure consistent inputs for our machine learning models.</p>
-    <a href="./data-standardization.md" class="card-link">Learn More →</a>
+    <a href="./data-standardization" class="card-link">Learn More →</a>
   </div>
 </div>
 
@@ -51,22 +51,22 @@ Forecasts are generated using ensemble methods that combine multiple model predi
 
 These technical concepts are frequently referenced:
 
-- **[Forecasting Models](./machine-learning/forecasting-models.md)**: Deep dive into ML model architecture
-- **[Data Standardization](./data-standardization.md)**: How we process and clean your data
-- **[Model Training](../api-reference/data-ingestion/upload-train.md)**: Upload training data for custom models
-- **[Forecast Accuracy](../guides/forecasting/improving-accuracy.md)**: Factors affecting forecast performance
+- **[Forecasting Models](./machine-learning/forecasting-models)**: Deep dive into ML model architecture
+- **[Data Standardization](./data-standardization)**: How we process and clean your data
+- **[Model Training](../api-reference/data-ingestion/upload-train)**: Upload training data for custom models
+- **[Forecast Accuracy](../guides/forecasting/improving-accuracy)**: Factors affecting forecast performance
 
 ## Next Steps
 
 Now that you understand our technical concepts:
 
-1. **Learn About Models**: Explore [Machine Learning Models](./machine-learning/forecasting-models.md) to understand our forecasting algorithms
-2. **Understand Data Processing**: Read [Data Standardization](./data-standardization.md) to see how we handle your data
-3. **Generate Forecasts**: Use the [Forecasting Guide](../guides/forecasting/overview.md) to apply this knowledge
-4. **API Integration**: Review the [API Reference](../api-reference/overview.md) for technical implementation details
+1. **Learn About Models**: Explore [Machine Learning Models](./machine-learning/forecasting-models) to understand our forecasting algorithms
+2. **Understand Data Processing**: Read [Data Standardization](./data-standardization) to see how we handle your data
+3. **Generate Forecasts**: Use the [Forecasting Guide](../guides/forecasting/overview) to apply this knowledge
+4. **API Integration**: Review the [API Reference](../api-reference/overview) for technical implementation details
 
 ## See Also
 
-- [Forecasting Guides](../guides/forecasting/overview.md) - How to use forecasting features
-- [API Reference](../api-reference/overview.md) - Technical API documentation
-- [Developer Guide](../guides/developer-guide.md) - Integration patterns and best practices
+- [Forecasting Guides](../guides/forecasting/overview) - How to use forecasting features
+- [API Reference](../api-reference/overview) - Technical API documentation
+- [Developer Guide](../guides/developer-guide) - Integration patterns and best practices

--- a/use-cases/overview.md
+++ b/use-cases/overview.md
@@ -9,7 +9,7 @@ Each use case demonstrates different aspects of our platform, from achieving hig
 
 ## Quick Start
 
-To understand how our platform delivers value, start with the [Sibaya Casino](./sibaya-casino.md) case study, which demonstrates achieving high forecast accuracy with limited historical data. This example shows how our generic models can provide immediate value even for new installations.
+To understand how our platform delivers value, start with the [Sibaya Casino](./sibaya-casino) case study, which demonstrates achieving high forecast accuracy with limited historical data. This example shows how our generic models can provide immediate value even for new installations.
 
 ## What You Can Find Here
 
@@ -17,19 +17,19 @@ To understand how our platform delivers value, start with the [Sibaya Casino](./
   <div class="overview-card">
     <h3>Sibaya Casino</h3>
     <p>A case study demonstrating how we achieved high forecast accuracy with limited historical data. This example shows the power of our generic models and data standardization pipeline, delivering accurate predictions even when historical data is sparse or incomplete.</p>
-    <a href="./sibaya-casino.md" class="card-link">Read Case Study →</a>
+    <a href="./sibaya-casino" class="card-link">Read Case Study →</a>
   </div>
   
   <div class="overview-card">
     <h3>Cummins Portfolio</h3>
     <p>Learn how we maintained operational continuity despite severe data loss. This case study demonstrates our platform's resilience and ability to continue generating accurate forecasts even when primary data sources fail, ensuring business operations remain uninterrupted.</p>
-    <a href="./cummins-portfolio.md" class="card-link">Read Case Study →</a>
+    <a href="./cummins-portfolio" class="card-link">Read Case Study →</a>
   </div>
   
   <div class="overview-card">
     <h3>Avaron Infrastructure</h3>
     <p>Discover how we unified intelligence across multiple stakeholders for portfolio-wide optimization. This example shows how our platform enables collaboration and data sharing across organizations, delivering value at both the asset and portfolio levels.</p>
-    <a href="./avaron-infrastructure.md" class="card-link">Read Case Study →</a>
+    <a href="./avaron-infrastructure" class="card-link">Read Case Study →</a>
   </div>
 </div>
 
@@ -57,22 +57,22 @@ Understand the ROI and business impact of implementing our platform, including r
 
 These case studies are frequently referenced:
 
-- **[Sibaya Casino](./sibaya-casino.md)**: High accuracy with limited data
-- **[Cummins Portfolio](./cummins-portfolio.md)**: Resilience during data loss
-- **[Avaron Infrastructure](./avaron-infrastructure.md)**: Multi-stakeholder collaboration
+- **[Sibaya Casino](./sibaya-casino)**: High accuracy with limited data
+- **[Cummins Portfolio](./cummins-portfolio)**: Resilience during data loss
+- **[Avaron Infrastructure](./avaron-infrastructure)**: Multi-stakeholder collaboration
 
 ## Next Steps
 
 Now that you've seen our use cases:
 
 1. **Read Case Studies**: Explore individual use cases to understand specific applications
-2. **Get Started**: Try our [Get Started](../get-started.md) guide to experience the platform yourself
-3. **Review Guides**: Check out our [Guides](../guides/overview.md) for step-by-step instructions
+2. **Get Started**: Try our [Get Started](../get-started) guide to experience the platform yourself
+3. **Review Guides**: Check out our [Guides](../guides/overview) for step-by-step instructions
 4. **Contact Us**: [Reach out to our team](mailto:support@asoba.co) to discuss your specific use case
 
 ## See Also
 
-- [Get Started](../get-started.md) - Try the platform yourself
-- [Guides](../guides/overview.md) - Step-by-step how-to guides
-- [API Reference](../api-reference/overview.md) - Technical implementation details
+- [Get Started](../get-started) - Try the platform yourself
+- [Guides](../guides/overview) - Step-by-step how-to guides
+- [API Reference](../api-reference/overview) - Technical implementation details
 - [Products](../products) - Platform products and capabilities


### PR DESCRIPTION
HTML links in overview pages (card links) were pointing to .md files, causing raw markdown to be served instead of processed HTML pages. Removed .md extensions from all href attributes in overview pages so Jekyll can properly route to the HTML versions.