### PR TITLE
Fix SVG diagram layout and encoding issues

### DIFF
--- a/assets/images/protocol/asoba-intelligence-enforcement-layers.svg
+++ b/assets/images/protocol/asoba-intelligence-enforcement-layers.svg
@@ -64,13 +64,6 @@
   <!-- Arrow from middle to top -->
   <path d="M 400 300 L 400 270" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
   
-  <!-- Right side callout -->
-  <rect x="600" y="80" width="180" height="60" fill="#fee2e2" stroke="#dc2626" stroke-width="2" rx="5"/>
-  <text x="690" y="105" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Important:</text>
-  <text x="690" y="125" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Tokens operate here</text>
-  <text x="690" y="140" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">&amp;mdash; not in customer</text>
-  <text x="690" y="155" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">workflows</text>
-  
   <!-- Arrow marker definition -->
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">

--- a/assets/images/protocol/delayed-enforcement-timeline.svg
+++ b/assets/images/protocol/delayed-enforcement-timeline.svg
@@ -31,7 +31,7 @@
   <text x="525" y="180" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#991b1b">Uncontained risk</text>
   <text x="525" y="200" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#991b1b">&amp; grid impact</text>
   
-  <text x="400" y="130" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-style="italic" fill="#991b1b">Cost of being wrong increases with time</text>
+  <text x="250" y="130" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-style="italic" fill="#991b1b">Cost of being wrong increases with time</text>
   
   <!-- Arrow showing delay -->
   <path d="M 400 280 L 650 280" stroke="#dc2626" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>

--- a/assets/images/protocol/enforcement-modes.svg
+++ b/assets/images/protocol/enforcement-modes.svg
@@ -1,16 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" style="background-color: #ffffff;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 550" style="background-color: #ffffff;">
   <!-- Title -->
   <text x="400" y="30" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" font-weight="bold">Continuous vs Discrete Enforcement Modes</text>
   
   <!-- Left Panel: Continuous Enforcement -->
-  <rect x="50" y="80" width="320" height="380" fill="#f0f9ff" stroke="#1e40af" stroke-width="2" rx="5"/>
+  <rect x="50" y="80" width="320" height="430" fill="#f0f9ff" stroke="#1e40af" stroke-width="2" rx="5"/>
   <text x="210" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="bold">Continuous Enforcement (Intraday)</text>
   
   <!-- Margin account -->
-  <rect x="100" y="150" width="220" height="80" fill="#dbeafe" stroke="#1e40af" stroke-width="2" rx="5"/>
+  <rect x="100" y="150" width="220" height="90" fill="#dbeafe" stroke="#1e40af" stroke-width="2" rx="5"/>
   <text x="210" y="180" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" font-weight="bold">Margin Account</text>
-  <text x="210" y="200" text-anchor="middle" font-family="Arial, sans-serif" font-size="12">Account-based collateral</text>
-  <text x="210" y="220" text-anchor="middle" font-family="Arial, sans-serif" font-size="12">balances</text>
+  <text x="210" y="200" text-anchor="middle" font-family="Arial, sans-serif" font-size="12">Account-based</text>
+  <text x="210" y="215" text-anchor="middle" font-family="Arial, sans-serif" font-size="12">collateral</text>
+  <text x="210" y="230" text-anchor="middle" font-family="Arial, sans-serif" font-size="12">balances</text>
   
   <!-- Net exposure line -->
   <line x1="120" y1="280" x2="300" y2="280" stroke="#3b82f6" stroke-width="3"/>
@@ -27,24 +28,27 @@
   <text x="210" y="420" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">- No NFT instruments</text>
   
   <!-- Right Panel: Discrete Enforcement -->
-  <rect x="430" y="80" width="320" height="380" fill="#fef3c7" stroke="#d97706" stroke-width="2" rx="5"/>
+  <rect x="430" y="80" width="320" height="430" fill="#fef3c7" stroke="#d97706" stroke-width="2" rx="5"/>
   <text x="590" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="bold">Discrete Enforcement (Commitments)</text>
   
   <!-- Commitment blocks -->
-  <rect x="460" y="150" width="260" height="50" fill="#fde68a" stroke="#d97706" stroke-width="2" rx="3"/>
-  <text x="590" y="175" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Commitment 1: Availability Guarantee</text>
-  <text x="590" y="190" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Scope: VPP | Duration: 6 months | Collateral: Locked</text>
+  <rect x="460" y="150" width="260" height="65" fill="#fde68a" stroke="#d97706" stroke-width="2" rx="3"/>
+  <text x="590" y="175" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Commitment 1: Availability</text>
+  <text x="590" y="190" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Guarantee</text>
+  <text x="590" y="205" text-anchor="middle" font-family="Arial, sans-serif" font-size="10">Scope: VPP | Duration: 6 months</text>
   
-  <rect x="460" y="220" width="260" height="50" fill="#fde68a" stroke="#d97706" stroke-width="2" rx="3"/>
-  <text x="590" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Commitment 2: Performance Financing</text>
-  <text x="590" y="260" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Scope: Battery upgrade | Duration: 12 months | Collateral: Locked</text>
+  <rect x="460" y="230" width="260" height="65" fill="#fde68a" stroke="#d97706" stroke-width="2" rx="3"/>
+  <text x="590" y="255" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Commitment 2: Performance</text>
+  <text x="590" y="270" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Financing</text>
+  <text x="590" y="285" text-anchor="middle" font-family="Arial, sans-serif" font-size="10">Scope: Battery upgrade | Duration: 12 months</text>
   
-  <rect x="460" y="290" width="260" height="50" fill="#fde68a" stroke="#d97706" stroke-width="2" rx="3"/>
-  <text x="590" y="315" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Commitment 3: Municipal SLA</text>
-  <text x="590" y="330" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Scope: Grid service | Duration: 3 months | Collateral: Locked</text>
+  <rect x="460" y="310" width="260" height="65" fill="#fde68a" stroke="#d97706" stroke-width="2" rx="3"/>
+  <text x="590" y="335" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Commitment 3: Municipal SLA</text>
+  <text x="590" y="350" text-anchor="middle" font-family="Arial, sans-serif" font-size="10">Scope: Grid service | Duration: 3 months</text>
+  <text x="590" y="365" text-anchor="middle" font-family="Arial, sans-serif" font-size="10">Collateral: Locked</text>
   
   <!-- Lifecycle -->
-  <text x="590" y="370" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold">Lifecycle:</text>
-  <text x="590" y="390" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Issuance ? Active ? Fulfilled/Expired</text>
-  <text x="590" y="410" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Clear audit trail over time</text>
+  <text x="590" y="400" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="bold">Lifecycle:</text>
+  <text x="590" y="420" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Issuance -&gt; Active -&gt; Fulfilled/Expired</text>
+  <text x="590" y="440" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Clear audit trail over time</text>
 </svg>

--- a/assets/images/protocol/external-capital-participation.svg
+++ b/assets/images/protocol/external-capital-participation.svg
@@ -48,7 +48,7 @@
   <path d="M 590 310 L 660 350" stroke="#16a34a" stroke-width="2" fill="none" marker-end="url(#arrowhead-green)"/>
   
   <!-- Success -->
-  <rect x="480" y="350" width="80" height="60" fill="#d1fae5" stroke="#16a34a" stroke-width="2" rx="5"/>
+  <rect x="480" y="350" width="80" height="75" fill="#d1fae5" stroke="#16a34a" stroke-width="2" rx="5"/>
   <text x="520" y="375" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Success</text>
   <text x="520" y="395" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Variable</text>
   <text x="520" y="410" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">compensation</text>

--- a/assets/images/protocol/failure-propagation.svg
+++ b/assets/images/protocol/failure-propagation.svg
@@ -12,15 +12,15 @@
   
   <!-- Arrows spreading outward -->
   <path d="M 210 250 L 150 320" stroke="#dc2626" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)"/>
-  <rect x="120" y="320" width="60" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
+  <rect x="100" y="320" width="100" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
   <text x="150" y="340" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Grid</text>
   
   <path d="M 210 250 L 210 320" stroke="#dc2626" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)"/>
-  <rect x="180" y="320" width="60" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
+  <rect x="160" y="320" width="100" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
   <text x="210" y="340" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Municipality</text>
   
   <path d="M 210 250 L 270 320" stroke="#dc2626" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)"/>
-  <rect x="240" y="320" width="60" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
+  <rect x="220" y="320" width="100" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
   <text x="270" y="340" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Counterparties</text>
   
   <text x="210" y="400" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-style="italic" fill="#991b1b">Penalties and instability propagate outward</text>

--- a/assets/images/protocol/token-scope.svg
+++ b/assets/images/protocol/token-scope.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" style="background-color: #ffffff;">
   <!-- Title -->
-  <text x="400" y="30" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" font-weight="bold">What the Token Is &amp;mdash; and Is Not</text>
+  <text x="400" y="30" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" font-weight="bold">What the Token Is — and Is Not</text>
   
   <!-- Central box: ASB-P Token -->
   <rect x="300" y="150" width="200" height="100" fill="#3b82f6" stroke="#1e40af" stroke-width="3" rx="5"/>


### PR DESCRIPTION
- Remove red callout box from image 1 (asoba-intelligence-enforcement-layers)
- Move 'cost of being wrong' text left in image 2 to avoid intersection
- Increase box widths in failure propagation image (No Collateral side)
- Increase Success box height in external capital image
- Increase box heights and improve text layout in enforcement modes image
- Fix em-dash display by using Unicode character instead of HTML entity