### PR TITLE
Fix SVG diagram layout issues

### DIFF
--- a/assets/images/protocol/advisory-vs-binding.svg
+++ b/assets/images/protocol/advisory-vs-binding.svg
@@ -45,15 +45,15 @@
   <text x="590" y="275" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Decision</text>
   
   <!-- Solid line to collateral -->
-  <path d="M 590 300 L 590 340" stroke="#16a34a" stroke-width="3" fill="none" marker-end="url(#arrowhead-green)"/>
+  <path d="M 590 300 L 590 325" stroke="#16a34a" stroke-width="3" fill="none" marker-end="url(#arrowhead-green)"/>
   
   <!-- Locked collateral -->
-  <rect x="550" y="340" width="80" height="50" fill="#86efac" stroke="#16a34a" stroke-width="2" rx="3"/>
-  <text x="590" y="365" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Locked</text>
-  <text x="590" y="380" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Collateral</text>
+  <rect x="550" y="325" width="80" height="50" fill="#86efac" stroke="#16a34a" stroke-width="2" rx="3"/>
+  <text x="590" y="350" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Locked</text>
+  <text x="590" y="365" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Collateral</text>
   
   <!-- Solid line to outcome -->
-  <path d="M 590 390 L 590 400" stroke="#16a34a" stroke-width="3" fill="none" marker-end="url(#arrowhead-green)"/>
+  <path d="M 590 375 L 590 400" stroke="#16a34a" stroke-width="3" fill="none" marker-end="url(#arrowhead-green)"/>
   
   <!-- Outcome -->
   <rect x="550" y="400" width="80" height="50" fill="#d1fae5" stroke="#16a34a" stroke-width="2" rx="3"/>

--- a/assets/images/protocol/asoba-intelligence-enforcement-layers.svg
+++ b/assets/images/protocol/asoba-intelligence-enforcement-layers.svg
@@ -3,25 +3,25 @@
   <text x="400" y="30" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" font-weight="bold">Asoba as the Intelligence + Enforcement Layer</text>
   
   <!-- Bottom Layer: Distributed Energy Assets -->
-  <rect x="50" y="450" width="700" height="100" fill="#e8f4f8" stroke="#2c5aa0" stroke-width="2" rx="5"/>
+  <rect x="50" y="450" width="700" height="120" fill="#e8f4f8" stroke="#2c5aa0" stroke-width="2" rx="5"/>
   <text x="400" y="480" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold">Distributed Energy Assets</text>
   
   <!-- Asset Icons -->
-  <circle cx="150" cy="520" r="25" fill="#10b981" opacity="0.7"/>
-  <text x="150" y="525" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">B</text>
-  <text x="150" y="555" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Batteries</text>
+  <circle cx="150" cy="530" r="25" fill="#10b981" opacity="0.7"/>
+  <text x="150" y="535" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">B</text>
+  <text x="150" y="560" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Batteries</text>
   
-  <circle cx="300" cy="520" r="25" fill="#f59e0b" opacity="0.7"/>
-  <text x="300" y="525" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">S</text>
-  <text x="300" y="555" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Solar</text>
+  <circle cx="300" cy="530" r="25" fill="#f59e0b" opacity="0.7"/>
+  <text x="300" y="535" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">S</text>
+  <text x="300" y="560" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Solar</text>
   
-  <circle cx="450" cy="520" r="25" fill="#3b82f6" opacity="0.7"/>
-  <text x="450" y="525" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">G</text>
-  <text x="450" y="555" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Generators</text>
+  <circle cx="450" cy="530" r="25" fill="#3b82f6" opacity="0.7"/>
+  <text x="450" y="535" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">G</text>
+  <text x="450" y="560" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Generators</text>
   
-  <rect x="575" y="495" width="50" height="30" fill="#6b7280" opacity="0.7" rx="3"/>
-  <text x="600" y="515" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="white">B</text>
-  <text x="600" y="555" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Buildings</text>
+  <rect x="575" y="505" width="50" height="30" fill="#6b7280" opacity="0.7" rx="3"/>
+  <text x="600" y="525" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="white">B</text>
+  <text x="600" y="560" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Buildings</text>
   
   <!-- Middle Layer: Asoba Intelligence Layer -->
   <rect x="50" y="300" width="700" height="120" fill="#f0f9ff" stroke="#1e40af" stroke-width="2" rx="5"/>
@@ -45,21 +45,20 @@
   <!-- Top Layer: Protocol Enforcement -->
   <rect x="50" y="150" width="700" height="120" fill="#fef3c7" stroke="#d97706" stroke-width="2" rx="5"/>
   <text x="400" y="180" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold">Protocol Enforcement Layer</text>
+  <text x="400" y="200" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-style="italic">Performance-collateralized commitments</text>
   
   <!-- Icons -->
-  <rect x="200" y="200" width="60" height="50" fill="#fbbf24" opacity="0.7" rx="3"/>
-  <text x="230" y="230" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold">LOCK</text>
-  <text x="230" y="260" text-anchor="middle" font-family="Arial, sans-serif" font-size="10">Lock</text>
+  <rect x="200" y="220" width="60" height="50" fill="#fbbf24" opacity="0.7" rx="3"/>
+  <text x="230" y="250" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold">LOCK</text>
+  <text x="230" y="265" text-anchor="middle" font-family="Arial, sans-serif" font-size="10">Lock</text>
   
-  <rect x="350" y="200" width="60" height="50" fill="#fbbf24" opacity="0.7" rx="3"/>
-  <text x="380" y="230" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold">BOND</text>
-  <text x="380" y="260" text-anchor="middle" font-family="Arial, sans-serif" font-size="10">Bond</text>
+  <rect x="350" y="220" width="60" height="50" fill="#fbbf24" opacity="0.7" rx="3"/>
+  <text x="380" y="250" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold">BOND</text>
+  <text x="380" y="265" text-anchor="middle" font-family="Arial, sans-serif" font-size="10">Bond</text>
   
-  <rect x="500" y="200" width="60" height="50" fill="#fbbf24" opacity="0.7" rx="3"/>
-  <text x="530" y="230" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold">TIME</text>
-  <text x="530" y="260" text-anchor="middle" font-family="Arial, sans-serif" font-size="10">Timer</text>
-  
-  <text x="400" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-style="italic">Performance-collateralized commitments</text>
+  <rect x="500" y="220" width="60" height="50" fill="#fbbf24" opacity="0.7" rx="3"/>
+  <text x="530" y="250" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold">TIME</text>
+  <text x="530" y="265" text-anchor="middle" font-family="Arial, sans-serif" font-size="10">Timer</text>
   
   <!-- Arrow from middle to top -->
   <path d="M 400 300 L 400 270" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>

--- a/assets/images/protocol/enforcement-modes.svg
+++ b/assets/images/protocol/enforcement-modes.svg
@@ -13,10 +13,11 @@
   <text x="210" y="215" text-anchor="middle" font-family="Arial, sans-serif" font-size="12">collateral</text>
   <text x="210" y="230" text-anchor="middle" font-family="Arial, sans-serif" font-size="12">balances</text>
   
-  <!-- Net exposure line -->
+  <!-- Net exposure line with polygon background -->
+  <polygon points="120,260 300,260 300,290 120,290" fill="#e0e7ff" opacity="0.5" stroke="none"/>
   <line x1="120" y1="280" x2="300" y2="280" stroke="#3b82f6" stroke-width="3"/>
   <path d="M 120 280 Q 180 250 240 260 Q 300 270 300 280" stroke="#3b82f6" stroke-width="2" fill="none"/>
-  <text x="210" y="270" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#1e40af">Fluctuating net exposure</text>
+  <text x="210" y="275" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#1e40af">Fluctuating net exposure</text>
   
   <!-- Collateral balance constraint -->
   <line x1="120" y1="320" x2="300" y2="320" stroke="#16a34a" stroke-width="2" stroke-dasharray="3,3"/>

--- a/assets/images/protocol/failure-propagation.svg
+++ b/assets/images/protocol/failure-propagation.svg
@@ -11,17 +11,17 @@
   <text x="210" y="210" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white">Failure</text>
   
   <!-- Arrows spreading outward -->
-  <path d="M 210 250 L 150 320" stroke="#dc2626" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)"/>
-  <rect x="100" y="320" width="100" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
-  <text x="150" y="340" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Grid</text>
+  <path d="M 210 250 L 120 340" stroke="#dc2626" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)"/>
+  <rect x="70" y="340" width="100" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
+  <text x="120" y="360" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Grid</text>
   
-  <path d="M 210 250 L 210 320" stroke="#dc2626" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)"/>
-  <rect x="160" y="320" width="100" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
-  <text x="210" y="340" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Municipality</text>
+  <path d="M 210 250 L 210 340" stroke="#dc2626" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)"/>
+  <rect x="160" y="340" width="100" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
+  <text x="210" y="360" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Municipality</text>
   
-  <path d="M 210 250 L 270 320" stroke="#dc2626" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)"/>
-  <rect x="220" y="320" width="100" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
-  <text x="270" y="340" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Counterparties</text>
+  <path d="M 210 250 L 300 340" stroke="#dc2626" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)"/>
+  <rect x="250" y="340" width="100" height="40" fill="#fee2e2" stroke="#dc2626" stroke-width="1" rx="3"/>
+  <text x="300" y="360" text-anchor="middle" font-family="Arial, sans-serif" font-size="11">Counterparties</text>
   
   <text x="210" y="400" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-style="italic" fill="#991b1b">Penalties and instability propagate outward</text>
   

--- a/assets/images/protocol/shared-risk-boundary.svg
+++ b/assets/images/protocol/shared-risk-boundary.svg
@@ -42,7 +42,4 @@
   
   <!-- Thick vertical line -->
   <line x1="400" y1="80" x2="400" y2="460" stroke="#000" stroke-width="4"/>
-  
-  <!-- Label on the line -->
-  <text x="400" y="280" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" stroke="#000" stroke-width="0.5">Failure externalizes cost</text>
 </svg>


### PR DESCRIPTION
- Spread out boxes in failure propagation image to prevent overlap
- Move 'performance collateralized commitments' text below header in image 1
- Increase height of Distributed Energy Assets box to fit labels
- Increase spacing in Intelligence + Collateral box to prevent arrow overlap
- Remove 'failure externalizes cost' label from shared-risk boundary image
- Add polygon background around 'fluctuating net exposure' label in enforcement modes